### PR TITLE
Adding commands in command palette

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,8 @@
+[{
+        "caption": "ConEmu: Open current file folder",
+        "command": "open_conemu_here",
+    }, {
+        "caption": "ConEmu: Open project or top folder",
+        "command": "open_conemu_project",
+    },
+]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ then use `Package Control` to install this package.
 ## Usage
 use `alt+c` to open current file's folder, use `ctrl+alt+c` to open the project or top folder.
 
+Command palette commands: `ConEmu: Open current file folder` and `ConEmu: Open project or top folder`.
+
 
 ## License :
 


### PR DESCRIPTION
For many users Sublime Text hotkeys <kbd>Alt+C</kbd> and <kbd>Ctrl+Alt+C</kbd> may already be involved, so it is always better if possible to run commands via Command Palette. Thanks.
