### PR TITLE
[Fixed] Spaces in folder name bug + I replace cmd to powershell

### DIFF
--- a/ConEmuOpen.py
+++ b/ConEmuOpen.py
@@ -19,7 +19,7 @@ class ConEmuOpenCommand():
         return (project_name, project_dir, has_project)
 
     def open_conemu(self, dirname, title):
-        command= "start conemu.exe /Single /Dir \""+dirname+"\" /cmdlist cmd -new_console:t:\""+title+"\""
+        command= "start conemu.exe /Single /Dir \""+dirname+"\" /cmdlist powershell -new_console:t:\""+title+"\""
         os.system(command)
 
 # open project folder

--- a/ConEmuOpen.py
+++ b/ConEmuOpen.py
@@ -19,43 +19,43 @@ class ConEmuOpenCommand():
         return (project_name, project_dir, has_project)
 
     def open_conemu(self, dirname, title):
-        command= "start conemu.exe /Single /Dir "+dirname+" /cmdlist cmd -new_console:t:\""+title+"\""
+        command= "start conemu.exe /Single /Dir \""+dirname+"\" /cmdlist cmd -new_console:t:\""+title+"\""
         os.system(command)
-        
+
 # open project folder
 class OpenConemuProjectCommand(sublime_plugin.WindowCommand, ConEmuOpenCommand):
     def run(self):
         project_name, project_dir, has_project = self.get_project()
         if not project_name:
             return
-            
+
         self.open_conemu(project_dir, project_name)
-        
+
 # open "here" folder
 class OpenConemuHereCommand(sublime_plugin.WindowCommand, ConEmuOpenCommand):
     def run(self, paths=[]):
         project_name, project_dir, has_project = self.get_project()
         if not project_name:
             return
-        
+
         if paths:
             heredir = paths[0]
             if os.path.isfile(heredir):
                 heredir = os.path.dirname(heredir)
-        elif self.window.active_view().file_name(): 
+        elif self.window.active_view().file_name():
             heredir = os.path.dirname(self.window.active_view().file_name())
         else: # if no active file open, then try to open project folder
             heredir = project_dir
-        
+
         # get the tab title
         title = heredir
-        if has_project: 
+        if has_project:
             rel_path = os.path.relpath(heredir, project_dir)
             if rel_path == '.':
                 title = project_name
             elif rel_path[:2] == '..': # not in project, show the whole path
                 title = heredir
-            else: 
+            else:
                 title = project_name + ': ' + rel_path
-        
+
         self.open_conemu(heredir, title)


### PR DESCRIPTION
1. I fixed a bug: if name of directory of file in which I run ConEmuOpen contained spaces, ConEmu not run. For example, if I run ConEmu in file of folder `E:\FolderNameWithoutSpaces`, ConEmu was run nice, but if I run ConEmu in file of folder `E:\Folder Name With Spaces`, ConEmu it was not run. 
2. I change `cmd` → `powershell`. PowerShell have more functionality, than `cmd.exe`.

Thanks.